### PR TITLE
Update signature for service methods

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 scalaVersion := "2.12.10"
 
-lazy val scalapbVersion = "0.10.8"
+val scalapbVersion = "0.10.8"
 
-lazy val Scala212 = "2.12.12"
-lazy val Scala213 = "2.13.3"
+val Scala212 = "2.12.12"
+val Scala213 = "2.13.3"
 
 ThisBuild / crossScalaVersions := Seq(Scala212, Scala213)
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,15 @@
 scalaVersion := "2.12.10"
 
-val scalapbVersion = "0.10.8"
+lazy val scalapbVersion = "0.10.8"
+
+lazy val Scala212 = "2.12.12"
+lazy val Scala213 = "2.13.3"
 
 ThisBuild / crossScalaVersions := Seq(Scala212, Scala213)
 
 skip in publish := true
 
 sonatypeProfileName := "com.thesamet"
-
-val Scala212 = "2.12.10"
-val Scala213 = "2.13.2"
 
 scalaVersion in ThisBuild := Scala213
 

--- a/code-gen/src/main/scala/scalapb/grpcweb/GrpcWebServicePrinter.scala
+++ b/code-gen/src/main/scala/scalapb/grpcweb/GrpcWebServicePrinter.scala
@@ -114,7 +114,8 @@ final class GrpcWebServicePrinter(
       "f(context)"
     ) ++
       (if (m.isClientStreaming) Seq.empty else Seq("request")) ++
-      (if (m.isClientStreaming || m.isServerStreaming) Seq("responseObserver") else Seq.empty)
+      (if (m.isClientStreaming || m.isServerStreaming) Seq("responseObserver")
+       else Seq.empty)
 
     val body = s"${clientCalls}.${methodName}(${args.mkString(", ")})"
     p.call(generateScalaDoc(m))

--- a/code-gen/src/main/scala/scalapb/grpcweb/GrpcWebServicePrinter.scala
+++ b/code-gen/src/main/scala/scalapb/grpcweb/GrpcWebServicePrinter.scala
@@ -36,7 +36,7 @@ final class GrpcWebServicePrinter(
       case StreamType.Unary =>
         s"${method.deprecatedAnnotation}def ${method.name}" + s"(request: ${method.inputType.scalaType}$contextParam): scala.concurrent.Future[${method.outputType.scalaType}]"
       case StreamType.ServerStreaming =>
-        s"${method.deprecatedAnnotation}def ${method.name}" + s"(request: ${method.inputType.scalaType}$contextParam, responseObserver: ${observer(method.outputType.scalaType)}): _root_.scalapb.grpcweb.native.ClientReadableStream"
+        s"${method.deprecatedAnnotation}def ${method.name}" + s"(request: ${method.inputType.scalaType}$contextParam, responseObserver: ${observer(method.outputType.scalaType)}): $clientCallStreamObserver"
       case _ =>
         throw new RuntimeException("Unexpected method type")
     }
@@ -61,6 +61,8 @@ final class GrpcWebServicePrinter(
 
   private[this] val abstractStub = "_root_.io.grpc.stub.AbstractStub"
   private[this] val streamObserver = "_root_.io.grpc.stub.StreamObserver"
+  private[this] val clientCallStreamObserver =
+    "_root_.io.grpc.stub.ClientCallStreamObserver"
 
   private[this] val clientCalls = "_root_.scalapb.grpc.ClientCalls"
 

--- a/code-gen/src/main/scala/scalapb/grpcweb/GrpcWebServicePrinter.scala
+++ b/code-gen/src/main/scala/scalapb/grpcweb/GrpcWebServicePrinter.scala
@@ -100,12 +100,12 @@ final class GrpcWebServicePrinter(
     }
 
   private[this] def clientMethodImpl(m: MethodDescriptor): PrinterEndo = { p =>
-    val (maybeObserver, methodName) = m.streamType match {
+    val (maybeObserver, methodName) = (m.streamType match {
       case StreamType.Unary => ("", "asyncUnaryCall")
       case StreamType.ServerStreaming =>
         (", responseObserver", "asyncServerStreamingCall")
       case _ => ???
-    }
+    })
 
     val args = Seq(
       "channel",
@@ -113,9 +113,10 @@ final class GrpcWebServicePrinter(
       "options",
       "f(context)"
     ) ++
-      (if (m.isClientStreaming) Seq.empty else Seq("request")) ++
-      (if (m.isClientStreaming || m.isServerStreaming) Seq("responseObserver")
-       else Seq.empty)
+      (if (m.isClientStreaming) Seq() else Seq("request")) ++
+      (if ((m.isClientStreaming || m.isServerStreaming))
+         Seq("responseObserver")
+       else Seq())
 
     val body = s"${clientCalls}.${methodName}(${args.mkString(", ")})"
     p.call(generateScalaDoc(m))
@@ -144,8 +145,8 @@ final class GrpcWebServicePrinter(
   private[this] val stub: PrinterEndo = {
     val methods =
       service.getMethods.asScala
-        .filter(isSupported)
-        .map(clientMethodImpl)
+        .filter(isSupported(_))
+        .map(clientMethodImpl(_))
         .toSeq
     stubImplementation(service.stub, service.name, methods)
   }

--- a/example/client/src/main/scala/scalapb/grpc/example/Client.scala
+++ b/example/client/src/main/scala/scalapb/grpc/example/Client.scala
@@ -30,7 +30,7 @@ object Client {
     val metadata2: Metadata = Metadata("custom-header-2" -> "streaming-value")
 
     // Make an async server streaming call
-    stub.serverStreaming(
+    val stream = stub.serverStreaming(
       req,
       metadata2,
       new StreamObserver[Res] {
@@ -47,5 +47,8 @@ object Client {
         }
       }
     )
+
+    // Cancel ongoing streamig call
+    //stream.cancel()
   }
 }

--- a/example/project/plugins.sbt
+++ b/example/project/plugins.sbt
@@ -13,4 +13,4 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.3"
 
 // publish locally and update the version for test
-libraryDependencies += "com.thesamet.scalapb.grpcweb" %% "scalapb-grpcweb-code-gen" % "0.3.0"
+libraryDependencies += "com.thesamet.scalapb.grpcweb" %% "scalapb-grpcweb-code-gen" % "0.4.1"

--- a/grpcweb/src/main/scala/io/grpc/grpc.scala
+++ b/grpcweb/src/main/scala/io/grpc/grpc.scala
@@ -4,7 +4,7 @@ import io.grpc.MethodDescriptor.MethodType
 import io.grpc.protobuf.ProtoFileDescriptorSupplier
 import scalapb.grpcweb.native.AbstractClientBase.MethodInfo
 import scalapb.grpcweb.native.GrpcWebClientBase
-import scalapb.grpcweb.native.{ErrorInfo, StatusInfo}
+import scalapb.grpcweb.native.{ClientReadableStream, ErrorInfo, StatusInfo}
 
 import scala.scalajs.js.typedarray.Uint8Array
 
@@ -21,6 +21,13 @@ package stub {
     def onError(throwable: Throwable): Unit
 
     def onCompleted(): Unit
+  }
+
+  abstract class ClientCallStreamObserver(
+      private val stream: ClientReadableStream
+  ) {
+    def cancel(): Unit =
+      stream.cancel()
   }
 
   abstract class AbstractStub[S <: AbstractStub[S]](

--- a/grpcweb/src/main/scala/scalapb/grpc/grpc.scala
+++ b/grpcweb/src/main/scala/scalapb/grpc/grpc.scala
@@ -1,7 +1,10 @@
 package scalapb.grpc
 
 import com.google.protobuf.Descriptors
-import io.grpc.protobuf.{ProtoFileDescriptorSupplier, ProtoMethodDescriptorSupplier}
+import io.grpc.protobuf.{
+  ProtoFileDescriptorSupplier,
+  ProtoMethodDescriptorSupplier
+}
 import io.grpc.stub.StreamObserver
 import io.grpc._
 import scalapb.grpcweb.Metadata
@@ -154,7 +157,14 @@ object ClientCalls {
       request: ReqT,
       responseObserver: StreamObserver[RespT]
   ): ClientReadableStream =
-    asyncServerStreamingCall(channel, method, options, Metadata.empty, request, responseObserver)
+    asyncServerStreamingCall(
+      channel,
+      method,
+      options,
+      Metadata.empty,
+      request,
+      responseObserver
+    )
 
   def asyncClientStreamingCall[ReqT, RespT](
       channel: Channel,

--- a/grpcweb/src/main/scala/scalapb/grpc/grpc.scala
+++ b/grpcweb/src/main/scala/scalapb/grpc/grpc.scala
@@ -109,7 +109,7 @@ object ClientCalls {
       metadata: Metadata,
       request: ReqT,
       responseObserver: StreamObserver[RespT]
-  ): ClientReadableStream =
+  ): ClientReadableStream = {
     channel.client
       .rpcCall(
         channel.baseUrl + "/" + method.fullName,
@@ -141,14 +141,14 @@ object ClientCalls {
         }
       )
       .on("end", { _: Any => responseObserver.onCompleted() })
+  }
 
   def asyncUnaryCall[ReqT, RespT](
       channel: Channel,
       method: MethodDescriptor[ReqT, RespT],
       options: CallOptions,
       request: ReqT
-  ): Future[RespT] =
-    asyncUnaryCall(channel, method, options, Metadata.empty, request)
+  ): Future[RespT] = ???
 
   def asyncServerStreamingCall[ReqT, RespT](
       channel: Channel,
@@ -156,15 +156,7 @@ object ClientCalls {
       options: CallOptions,
       request: ReqT,
       responseObserver: StreamObserver[RespT]
-  ): ClientReadableStream =
-    asyncServerStreamingCall(
-      channel,
-      method,
-      options,
-      Metadata.empty,
-      request,
-      responseObserver
-    )
+  ): ClientReadableStream = ???
 
   def asyncClientStreamingCall[ReqT, RespT](
       channel: Channel,
@@ -192,9 +184,5 @@ object ClientCalls {
       method: MethodDescriptor[ReqT, RespT],
       options: CallOptions,
       request: ReqT
-  ): RespT =
-    Await.result(
-      asyncUnaryCall(channel, method, options, request),
-      Duration.apply(1L, scala.concurrent.duration.MINUTES)
-    )
+  ): RespT = ???
 }


### PR DESCRIPTION
This will update the signature for service methods, giving access to `ClientReadableStream` and having the possibility to `.cancel()` ongoing requests. 
Please let me know if something is not right or if it should go in a different direction.