### PR TITLE
Invoke serverStreaming instead of rpcCall for server streaming

### DIFF
--- a/grpcweb/src/main/scala/scalapb/grpc/grpc.scala
+++ b/grpcweb/src/main/scala/scalapb/grpc/grpc.scala
@@ -116,7 +116,7 @@ object ClientCalls {
       responseObserver: StreamObserver[RespT]
   ): ClientCallStreamObserver = {
     val stream = channel.client
-      .rpcCall(
+      .serverStreaming(
         channel.baseUrl + "/" + method.fullName,
         request,
         metadata,


### PR DESCRIPTION
`serverStreaming` function should be invoked for server streaming calls instead of `rpcCall`. Using `rpcCall` for server streaming results in "data" events being ignored and also in a JS type error at the end of the operation.

I tested this simple change with the provided example project using Scala 2.13.5.

Also see the relevant discussion on gitter: https://gitter.im/ScalaPB/community?at=6066981a56ddab18d724464b