### PR TITLE
Align API with grpc-java

### DIFF
--- a/code-gen/src/main/scala/scalapb/grpcweb/GrpcWebServicePrinter.scala
+++ b/code-gen/src/main/scala/scalapb/grpcweb/GrpcWebServicePrinter.scala
@@ -21,8 +21,11 @@ final class GrpcWebServicePrinter(
   def scalaFileName =
     OuterObject.fullName.replace('.', '/') + ".scala"
 
-  private[this] def observer(typeParam: String): String =
-    s"$streamObserver[$typeParam]"
+  private[this] def streamObserver(typeParam: String): String =
+    s"_root_.io.grpc.stub.StreamObserver[$typeParam]"
+
+  private[this] def clientCallStreamObserver(typeParam: String): String =
+    s"_root_.io.grpc.stub.ClientCallStreamObserver[$typeParam]"
 
   def isSupported(m: MethodDescriptor): Boolean =
     (m.streamType == StreamType.Unary || m.streamType == StreamType.ServerStreaming)
@@ -36,7 +39,9 @@ final class GrpcWebServicePrinter(
       case StreamType.Unary =>
         s"${method.deprecatedAnnotation}def ${method.name}" + s"(request: ${method.inputType.scalaType}$contextParam): scala.concurrent.Future[${method.outputType.scalaType}]"
       case StreamType.ServerStreaming =>
-        s"${method.deprecatedAnnotation}def ${method.name}" + s"(request: ${method.inputType.scalaType}$contextParam, responseObserver: ${observer(method.outputType.scalaType)}): $clientCallStreamObserver"
+        s"${method.deprecatedAnnotation}def ${method.name}" + s"(request: ${method.inputType.scalaType}$contextParam, responseObserver: ${streamObserver(
+          method.outputType.scalaType
+        )}): ${clientCallStreamObserver(method.outputType.scalaType)}"
       case _ =>
         throw new RuntimeException("Unexpected method type")
     }
@@ -59,9 +64,6 @@ final class GrpcWebServicePrinter(
   private[this] val callOptions = "_root_.io.grpc.CallOptions"
 
   private[this] val abstractStub = "_root_.io.grpc.stub.AbstractStub"
-  private[this] val streamObserver = "_root_.io.grpc.stub.StreamObserver"
-  private[this] val clientCallStreamObserver =
-    "_root_.io.grpc.stub.ClientCallStreamObserver"
 
   private[this] val clientCalls = "_root_.scalapb.grpc.ClientCalls"
 

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -3,7 +3,7 @@ import sbtcrossproject.CrossPlugin.autoImport.{CrossType, crossProject}
 
 name := "scalapb-grpcweb-example"
 
-ThisBuild / scalaVersion := "3.0.0-RC1"
+ThisBuild / scalaVersion := "2.13.5"
 
 ThisBuild / resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots"),
@@ -22,7 +22,6 @@ lazy val protos =
         scalapb.gen() -> (Compile / sourceManaged).value
       ),
       libraryDependencies += "com.thesamet.scalapb" %%% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion,
-      scalacOptions += "-source:3.0-migration"
     )
     .jvmSettings(
       libraryDependencies += "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion

--- a/example/index.html
+++ b/example/index.html
@@ -6,6 +6,6 @@
   </head>
   <body>
     <!-- Include Scala.js compiled code -->
-    <script type="text/javascript" src="client/target/scala-2.12/scalajs-bundler/main/client-fastopt-bundle.js"></script>
+    <script type="text/javascript" src="client/target/scala-2.13/scalajs-bundler/main/client-fastopt-bundle.js"></script>
   </body>
 </html>

--- a/grpcweb/src/main/scala/io/grpc/grpc.scala
+++ b/grpcweb/src/main/scala/io/grpc/grpc.scala
@@ -23,10 +23,10 @@ package stub {
     def onCompleted(): Unit
   }
 
-  abstract class ClientCallStreamObserver(
-      private val stream: ClientReadableStream
+  abstract class ClientCallStreamObserver[RespT](
+      private val stream: ClientReadableStream[RespT]
   ) {
-    def cancel(): Unit =
+    def cancel(message: String, cause: Throwable): Unit =
       stream.cancel()
   }
 

--- a/grpcweb/src/main/scala/scalapb/grpc/grpc.scala
+++ b/grpcweb/src/main/scala/scalapb/grpc/grpc.scala
@@ -78,8 +78,9 @@ object ConcreteProtoMethodDescriptorSupplier {
     new ConcreteProtoMethodDescriptorSupplier()
 }
 
-class AsyncClientCallStreamObserver(private val stream: ClientReadableStream)
-    extends ClientCallStreamObserver(stream)
+class AsyncClientCallStreamObserver[RespT](
+    private val stream: ClientReadableStream[RespT]
+) extends ClientCallStreamObserver(stream)
 
 object ClientCalls {
   def asyncUnaryCall[ReqT, RespT](
@@ -114,7 +115,7 @@ object ClientCalls {
       metadata: Metadata,
       request: ReqT,
       responseObserver: StreamObserver[RespT]
-  ): ClientCallStreamObserver = {
+  ): ClientCallStreamObserver[RespT] = {
     val stream = channel.client
       .serverStreaming(
         channel.baseUrl + "/" + method.fullName,
@@ -163,7 +164,7 @@ object ClientCalls {
       options: CallOptions,
       request: ReqT,
       responseObserver: StreamObserver[RespT]
-  ): ClientCallStreamObserver = ???
+  ): ClientCallStreamObserver[RespT] = ???
 
   def asyncClientStreamingCall[ReqT, RespT](
       channel: Channel,

--- a/grpcweb/src/main/scala/scalapb/grpcweb/native.scala
+++ b/grpcweb/src/main/scala/scalapb/grpcweb/native.scala
@@ -18,21 +18,21 @@ object native extends js.Object {
         metadata: Metadata,
         methodInfo: AbstractClientBase.MethodInfo[Req, Res],
         callback: js.Function2[ErrorInfo, Res, Unit]
-    ): ClientReadableStream = js.native
+    ): ClientReadableStream[Res] = js.native
 
     def rpcCall[Req, Res](
         method: String,
         request: Req,
         metadata: Metadata,
         methodInfo: AbstractClientBase.MethodInfo[Req, Res]
-    ): ClientReadableStream = js.native
+    ): ClientReadableStream[Res] = js.native
 
     def serverStreaming[Req, Res](
         method: String,
         request: Req,
         metadata: Metadata,
         methodInfo: AbstractClientBase.MethodInfo[Req, Res]
-    ): ClientReadableStream = js.native
+    ): ClientReadableStream[Res] = js.native
   }
 
   @js.native
@@ -46,13 +46,16 @@ object native extends js.Object {
   }
 
   @js.native
-  class ClientReadableStream extends js.Any {
-    def on[T](
+  class ClientReadableStream[Res] extends js.Any {
+    def on[A](
         `type`: String,
-        callback: js.Function1[T, Unit]
-    ): ClientReadableStream = js.native
+        callback: js.Function1[A, Unit]
+    ): ClientReadableStream[Res] = js.native
 
-    def on(`type`: String, callback: js.Function0[Unit]): ClientReadableStream =
+    def on(
+        `type`: String,
+        callback: js.Function0[Unit]
+    ): ClientReadableStream[Res] =
       js.native
 
     def cancel(): Unit = js.native


### PR DESCRIPTION
Changes (in separate commits):
* Downgrade Scala in example project to 2.13
    * I had to do that for the example project to build
* Implement Status/Code API to match the one in grpc-java 
   *  I drew inspiration from scala-java-time on how to create Java-compatible "enums" 
* Align stream API with grpc-java
   * the `cancel` method accepts parameters in Java API
   * the stream observers have a type parameter 

Testing:
- I followed instructions from the example project README and checked if the JS console displays expected info