### PR TITLE
[WIP] Update grpc-web (npm lib) to 1.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -90,7 +90,7 @@ lazy val grpcweb = project
       case Some((3, _)) => List("-source:3.0-migration")
       case _            => Nil
     }),
-    Compile / npmDependencies += "grpc-web" -> "1.2.1"
+    Compile / npmDependencies += "grpc-web" -> "1.3.0"
   )
 
 inThisBuild(


### PR DESCRIPTION
Would be possible to update the npm package grpc-web in your next release. 
https://www.npmjs.com/package/grpc-web

BTW I have no idea how the example project is getting access to this npm package.